### PR TITLE
Add pandas-based FRM file reader and writer

### DIFF
--- a/frm.py
+++ b/frm.py
@@ -1,0 +1,48 @@
+"""Utilities for reading and writing FRM files using pandas."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def read_frm(path: str | Path, *, encoding: str = "utf-8") -> pd.DataFrame:
+    """Read a FRM file into a :class:`pandas.DataFrame`.
+
+    Parameters
+    ----------
+    path:
+        Path to the FRM file.
+    encoding:
+        Text encoding to use when reading the file. Defaults to ``"utf-8"``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame constructed from the FRM contents.
+    """
+    file_path = Path(path)
+    if not file_path.exists():
+        raise FileNotFoundError(file_path)
+    return pd.read_csv(file_path, encoding=encoding)
+
+
+def write_frm(
+    df: pd.DataFrame, path: str | Path, *, encoding: str = "utf-8"
+) -> None:
+    """Write a :class:`pandas.DataFrame` to a FRM file.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to serialize.
+    path:
+        Destination file path.
+    encoding:
+        Text encoding to use when writing the file. Defaults to ``"utf-8"``.
+    """
+    file_path = Path(path)
+    df.to_csv(file_path, index=False, encoding=encoding)
+
+
+__all__ = ["read_frm", "write_frm"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch
 numpy
 tiktoken
 PyYAML
+pandas

--- a/tests/test_frm.py
+++ b/tests/test_frm.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from frm import read_frm, write_frm  # noqa: E402
+
+
+def test_round_trip(tmp_path):
+    df = pd.DataFrame({'a': [1, 2], 'b': ['x', 'y']})
+    file_path = tmp_path / 'sample.frm'
+    write_frm(df, file_path)
+    loaded = read_frm(file_path)
+    assert loaded.equals(df)


### PR DESCRIPTION
## Summary
- add `read_frm` and `write_frm` utilities using pandas for handling FRM files
- include tests ensuring round-trip FRM serialization works
- declare pandas dependency

## Testing
- `flake8 frm.py tests/test_frm.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689de6764b48832995cb04441c0e0f29