### PR TITLE
Handle missing git repository gracefully

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -412,7 +412,9 @@ def get_current_commit() -> str:
     """
     try:
         return (
-            subprocess.check_output(['git', 'rev-parse', 'HEAD'])
+            subprocess.check_output(
+                ['git', 'rev-parse', 'HEAD'], stderr=subprocess.DEVNULL
+            )
             .decode('utf-8')
             .strip()
         )


### PR DESCRIPTION
## Summary
- avoid noisy fatal logs when `.git` is absent by silencing `git` stderr
- return an empty commit hash when repository isn't available

## Testing
- `pytest`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_689e8610b9448329bd7297dee4f42ecc