### PR TITLE
Ensure lines log directory exists

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -161,6 +161,7 @@ def store_line(line: str) -> float:
     except Exception:
         logging.exception("Failed to store line")
         return 0.0
+    LINES_FILE.parent.mkdir(parents=True, exist_ok=True)
     with LINES_FILE.open('a', encoding='utf-8') as f:
         f.write(line + '\n')
     weight = perplexity + resonance


### PR DESCRIPTION
## Summary
- ensure `LINES_FILE` parent directory is created before appending user lines

## Testing
- `pytest`
- `flake8` *(fails: line too long and other style issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689e90f351208329991cf110ca8e76c1