### PR TITLE
Trim stored user lines and ensure log truncation

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -171,12 +171,11 @@ def store_line(line: str) -> float:
 
 def trim_user_lines(max_lines: int = MAX_USER_LINES) -> None:
     """Trim user_lines, weights, and log file to the last max_lines entries."""
-    if len(user_lines) <= max_lines:
-        return
-    del user_lines[:-max_lines]
-    del user_weights[:-max_lines]
+    if len(user_lines) > max_lines:
+        del user_lines[:-max_lines]
+        del user_weights[:-max_lines]
     with LINES_FILE.open('w', encoding='utf-8') as f:
-        for line in user_lines:
+        for line in user_lines[-max_lines:]:
             f.write(line + '\n')
 
 
@@ -268,6 +267,7 @@ async def send_chunk(app: Application, chat_id: int, state: ChatState) -> None:
         chunk = f"{prefix} {chunk}"
     entropy, perplexity, _ = compute_metrics(chunk)
     store_line(chunk)
+    trim_user_lines()
     delay = random.randint(3, 6) if state.awaiting_response else random.randint(1, 3)
     await simulate_typing(app.bot, chat_id, delay)
     state.awaiting_response = False

--- a/tests/test_trim_user_lines.py
+++ b/tests/test_trim_user_lines.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import molly  # noqa: E402
+
+
+def test_trim_user_lines(tmp_path):
+    molly.LINES_FILE = tmp_path / "lines.txt"
+    molly.user_lines = [f"line {i}" for i in range(10)]
+    molly.user_weights = [float(i) for i in range(10)]
+    molly.LINES_FILE.write_text("\n".join(molly.user_lines) + "\n", encoding="utf-8")
+    molly.trim_user_lines(max_lines=5)
+    assert molly.user_lines == [f"line {i}" for i in range(5, 10)]
+    assert molly.user_weights == [float(i) for i in range(5, 10)]
+    content = molly.LINES_FILE.read_text(encoding="utf-8").splitlines()
+    assert content == [f"line {i}" for i in range(5, 10)]


### PR DESCRIPTION
## Summary
- Trim user line list and log file every time a chunk is stored
- Verify trimming logic with a new unit test

## Testing
- `ruff check molly.py tests/test_trim_user_lines.py tests/test_frm.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e90eb160c83298db3c141996e9f60