### PR TITLE
Ensure monitor_repo closes DB connection

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -465,30 +465,35 @@ async def monitor_repo() -> None:
     prev_commit = ""
     conn = sqlite3.connect(CHANGELOG_DB)
     init_change_db(conn)
-    while True:
-        try:
-            current_commit = get_current_commit()
-            if not current_commit:
-                await asyncio.sleep(300)
-                continue
-            if prev_commit and current_commit != prev_commit:
-                diff = get_diff(prev_commit, current_commit)
-                repo_hash = repo_sha256(current_commit)
-                conn.execute(
-                    "INSERT INTO changes (commit_hash, repo_hash, diff, size, created_at) VALUES (?, ?, ?, ?, ?)",
-                    (
-                        current_commit,
-                        repo_hash,
-                        diff,
-                        len(diff.encode('utf-8')),
-                        datetime.now(UTC).isoformat(),
-                    ),
-                )
-                conn.commit()
-            prev_commit = current_commit
-        except Exception:
-            logging.exception("Failed to monitor repository changes")
-        await asyncio.sleep(300)
+    try:
+        while True:
+            try:
+                current_commit = get_current_commit()
+                if not current_commit:
+                    await asyncio.sleep(300)
+                    continue
+                if prev_commit and current_commit != prev_commit:
+                    diff = get_diff(prev_commit, current_commit)
+                    repo_hash = repo_sha256(current_commit)
+                    conn.execute(
+                        "INSERT INTO changes (commit_hash, repo_hash, diff, size, created_at) VALUES (?, ?, ?, ?, ?)",
+                        (
+                            current_commit,
+                            repo_hash,
+                            diff,
+                            len(diff.encode('utf-8')),
+                            datetime.now(UTC).isoformat(),
+                        ),
+                    )
+                    conn.commit()
+                prev_commit = current_commit
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logging.exception("Failed to monitor repository changes")
+            await asyncio.sleep(300)
+    finally:
+        conn.close()
 
 
 def get_last_commit(conn: sqlite3.Connection) -> str | None:


### PR DESCRIPTION
## Summary
- Wrap `monitor_repo` body in `try`/`finally` to always close the changelog database connection
- Let `asyncio.CancelledError` propagate so cancellation triggers cleanup

## Testing
- `pytest -q`
- `flake8 molly.py` *(fails: E501 line too long and other style issues)*

------
https://chatgpt.com/codex/tasks/task_e_689e9189701c83299fc8c1a93865bc06