### PR TITLE
Refactor random chunk generation and add test

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -204,15 +204,48 @@ def text_chunks() -> Iterator[str]:
 
 
 def random_chunks() -> Iterator[str]:
-    """Yield text chunks starting from a random position."""
-    chunks = list(text_chunks())
-    if not chunks:
+    """Yield text chunks starting from a random byte offset.
+
+    The file is read sequentially in blocks beginning at a random position.
+    When the end of the file is reached the reader wraps to the start and
+    continues until the starting offset is encountered again.
+    """
+
+    size = ORIGIN_TEXT.stat().st_size
+    if size == 0:
         return
-    start = random.randrange(len(chunks))
-    for chunk in chunks[start:]:
-        yield chunk
-    for chunk in chunks[:start]:
-        yield chunk
+
+    start = random.randrange(size)
+    block_size = MAX_MESSAGE_LENGTH
+
+    def block_iter() -> Iterator[str]:
+        with ORIGIN_TEXT.open("rb") as f:
+            f.seek(start)
+            remaining = size
+            while remaining > 0:
+                to_read = min(block_size, remaining)
+                data = f.read(to_read)
+                if not data:
+                    f.seek(0)
+                    continue
+                remaining -= len(data)
+                yield data.decode("utf-8", errors="ignore")
+
+    buffer = ""
+    for data in block_iter():
+        buffer += data
+        while len(buffer) >= MAX_MESSAGE_LENGTH:
+            split_pos = buffer.rfind(" ", 0, MAX_MESSAGE_LENGTH)
+            if split_pos == -1:
+                split_pos = buffer.find(" ", MAX_MESSAGE_LENGTH)
+                if split_pos == -1:
+                    break
+            chunk, buffer = buffer[:split_pos], buffer[split_pos + 1 :]
+            if chunk:
+                yield chunk
+    remainder = buffer.strip()
+    if remainder:
+        yield remainder
 
 
 async def simulate_typing(bot, chat_id: int, delay: int) -> None:

--- a/tests/test_random_chunks.py
+++ b/tests/test_random_chunks.py
@@ -1,0 +1,66 @@
+import ast
+import random
+import re
+from pathlib import Path
+from typing import Iterator
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = (ROOT / "molly.py").read_text(encoding="utf-8")
+
+# Extract constants
+ORIGIN_TEXT = ROOT / re.search(r"^ORIGIN_TEXT = Path\('([^']+)'\)", SOURCE, re.MULTILINE).group(1)
+MAX_MESSAGE_LENGTH = int(re.search(r"^MAX_MESSAGE_LENGTH = (\d+)", SOURCE, re.MULTILINE).group(1))
+
+# Extract random_chunks function without importing heavy dependencies
+module = {}
+for node in ast.parse(SOURCE).body:
+    if isinstance(node, ast.FunctionDef) and node.name == "random_chunks":
+        func_code = ast.Module(body=[node], type_ignores=[])
+        exec(
+            compile(func_code, filename="molly.py", mode="exec"),
+            {
+                "Path": Path,
+                "random": random,
+                "Iterator": Iterator,
+                "ORIGIN_TEXT": ORIGIN_TEXT,
+                "MAX_MESSAGE_LENGTH": MAX_MESSAGE_LENGTH,
+            },
+            module,
+        )
+        break
+random_chunks = module["random_chunks"]
+
+
+def chunk_string(text: str) -> list[str]:
+    buffer = text
+    chunks = []
+    while len(buffer) >= MAX_MESSAGE_LENGTH:
+        split_pos = buffer.rfind(" ", 0, MAX_MESSAGE_LENGTH)
+        if split_pos == -1:
+            split_pos = buffer.find(" ", MAX_MESSAGE_LENGTH)
+            if split_pos == -1:
+                break
+        chunk, buffer = buffer[:split_pos], buffer[split_pos + 1 :]
+        if chunk:
+            chunks.append(chunk)
+    remainder = buffer.strip()
+    if remainder:
+        chunks.append(remainder)
+    return chunks
+
+
+def rotated_content(offset: int) -> str:
+    with ORIGIN_TEXT.open("rb") as f:
+        f.seek(offset)
+        part1 = f.read()
+        f.seek(0)
+        part2 = f.read(offset)
+    return (part1 + part2).decode("utf-8", errors="ignore")
+
+
+def test_random_chunks_rotation(monkeypatch):
+    offset = 123
+    monkeypatch.setattr(random, "randrange", lambda _: offset)
+    expected_text = rotated_content(offset)
+    expected_chunks = chunk_string(expected_text)
+    assert list(random_chunks()) == expected_chunks


### PR DESCRIPTION
## Summary
- stream origin text from a random byte offset without loading all chunks into memory
- add unit test ensuring random_chunks yields rotated content correctly

## Testing
- `ruff check molly.py tests/test_random_chunks.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e919d526483299091c37d656dcbdb