### PR TITLE
Use asyncio.to_thread for store_line I/O

### DIFF
--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import math
 import sqlite3
 
+import asyncio
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -36,7 +37,7 @@ def test_store_line(tmp_path, monkeypatch):
     molly.user_weights.clear()
     molly.db_conn = None
     molly.init_db()
-    weight = molly.store_line("Love 123")
+    weight = asyncio.run(molly.store_line("Love 123"))
     entropy, perplexity, resonance = molly.compute_metrics("Love 123")
     assert weight == pytest.approx(perplexity + resonance)
     assert molly.user_lines == ["Love 123"]


### PR DESCRIPTION
## Summary
- Offload synchronous database and file writes in `store_line` to `asyncio.to_thread`
- Adjust `test_store_line` to run coroutine with `asyncio.run`

## Testing
- `python -m flake8 tests/test_molly.py molly.py` *(fails: numerous style errors in existing code)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ee516e41483298ac648115ae13b7e