### PR TITLE
Trim user line log efficiently

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -179,9 +179,12 @@ def trim_user_lines(max_lines: int = MAX_USER_LINES) -> None:
         return
     del user_lines[:-max_lines]
     del user_weights[:-max_lines]
-    with LINES_FILE.open('w', encoding='utf-8') as f:
-        for line in user_lines:
-            f.write(line + '\n')
+    with LINES_FILE.open("r+", encoding="utf-8") as f:
+        f.seek(0)
+        lines = f.readlines()
+        f.seek(0)
+        f.writelines(lines[-max_lines:])
+        f.truncate()
 
 
 def text_chunks() -> Iterator[str]:
@@ -406,7 +409,8 @@ async def handle_message(
     weights = []
     for line in lines:
         weights.append(await store_line(line))
-    trim_user_lines()
+    if len(user_lines) > MAX_USER_LINES:
+        trim_user_lines()
     chat_id = update.effective_chat.id
     state = chat_states.setdefault(chat_id, ChatState())
     if weights:

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 import math
 import sqlite3
+import asyncio
 
 import pytest
 
@@ -36,7 +37,7 @@ def test_store_line(tmp_path, monkeypatch):
     molly.user_weights.clear()
     molly.db_conn = None
     molly.init_db()
-    weight = molly.store_line("Love 123")
+    weight = asyncio.run(molly.store_line("Love 123"))
     entropy, perplexity, resonance = molly.compute_metrics("Love 123")
     assert weight == pytest.approx(perplexity + resonance)
     assert molly.user_lines == ["Love 123"]


### PR DESCRIPTION
## Summary
- call `trim_user_lines` only when the stored user lines exceed `MAX_USER_LINES`
- shrink the lines log file in-place using seek and truncate
- update tests to await the async `store_line`

## Testing
- `flake8`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ee5652db48329be33e1695a723f7e