### PR TITLE
Invoke repo monitoring on startup

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -443,6 +443,7 @@ def main() -> None:
     init_db()
 
     async def post_init(app: Application) -> None:
+        monitor_repo_once()
         background_tasks.append(asyncio.create_task(cleanup_chat_states()))
         background_tasks.append(asyncio.create_task(monitor_repo()))
 

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -36,7 +36,9 @@ def test_store_line(tmp_path, monkeypatch):
     molly.user_weights.clear()
     molly.db_conn = None
     molly.init_db()
-    weight = molly.store_line("Love 123")
+    import asyncio
+
+    weight = asyncio.run(molly.store_line("Love 123"))
     entropy, perplexity, resonance = molly.compute_metrics("Love 123")
     assert weight == pytest.approx(perplexity + resonance)
     assert molly.user_lines == ["Love 123"]


### PR DESCRIPTION
## Summary
- Call `monitor_repo_once` during post-initialization so repository changes are checked at startup
- Adjust `test_store_line` to run async `store_line` using `asyncio.run`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ee58007a88329a3744a24532f0ae5