### PR TITLE
Handle zero-weight case for prefix selection

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -406,10 +406,11 @@ async def handle_message(
     weights = []
     for line in lines:
         weights.append(await store_line(line))
+    total_weight = sum(weights)
     trim_user_lines()
     chat_id = update.effective_chat.id
     state = chat_states.setdefault(chat_id, ChatState())
-    if weights:
+    if weights and total_weight > 0:
         state.next_prefix = random.choices(lines, weights=weights, k=1)[0]
     else:
         state.next_prefix = random.choice(lines)

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 import math
 import sqlite3
+import asyncio
 
 import pytest
 
@@ -36,7 +37,7 @@ def test_store_line(tmp_path, monkeypatch):
     molly.user_weights.clear()
     molly.db_conn = None
     molly.init_db()
-    weight = molly.store_line("Love 123")
+    weight = asyncio.run(molly.store_line("Love 123"))
     entropy, perplexity, resonance = molly.compute_metrics("Love 123")
     assert weight == pytest.approx(perplexity + resonance)
     assert molly.user_lines == ["Love 123"]


### PR DESCRIPTION
## Summary
- Avoid selecting prefixes with zero total weight by falling back to `random.choice`
- Await `store_line` in tests using `asyncio.run`

## Testing
- `pytest`
- `flake8 molly.py tests/test_molly.py` *(fails: many E*** issues)*

------
https://chatgpt.com/codex/tasks/task_e_689ee5f73af48329ae207080dcd0cffc