### PR TITLE
Use pytest asyncio for store_line test

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -179,9 +179,9 @@ async def _store_line(line: str) -> float:
     return weight
 
 
-def store_line(line: str) -> float:
-    """Synchronous wrapper around _store_line for ease of use."""
-    return asyncio.run(_store_line(line))
+async def store_line(line: str) -> float:
+    """Persist a line to storage and return its weight."""
+    return await _store_line(line)
 
 
 def trim_user_lines(max_lines: int = MAX_USER_LINES) -> None:

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -2,9 +2,6 @@ import sys
 from pathlib import Path
 import math
 import sqlite3
-import asyncio
-
-import asyncio
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -29,7 +26,8 @@ def test_prepare_lines(monkeypatch):
     assert lines == ["123 456 789", "Good day"]
 
 
-def test_store_line(tmp_path, monkeypatch):
+@pytest.mark.asyncio
+async def test_store_line(tmp_path, monkeypatch):
     db_path = tmp_path / "lines.db"
     lines_file = tmp_path / "lines.txt"
     monkeypatch.setattr(molly, "DB_PATH", db_path)
@@ -38,7 +36,7 @@ def test_store_line(tmp_path, monkeypatch):
     molly.user_weights.clear()
     molly.db_conn = None
     molly.init_db()
-    weight = asyncio.run(molly.store_line("Love 123"))
+    weight = await molly.store_line("Love 123")
     entropy, perplexity, resonance = molly.compute_metrics("Love 123")
     assert weight == pytest.approx(perplexity + resonance)
     assert molly.user_lines == ["Love 123"]


### PR DESCRIPTION
## Summary
- mark store_line test as async and await the function
- make store_line itself async instead of using asyncio.run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eedc34c24832984facb76b6ccee63