### PR TITLE
Use aiosqlite for async DB operations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy==2.3.2
 tiktoken==0.11.0
 PyYAML==6.0.2
 pandas==2.3.1
+aiosqlite==0.20.0


### PR DESCRIPTION
## Summary
- replace synchronous sqlite3 usage with aiosqlite
- initialize and close DB asynchronously within the bot lifecycle
- adjust tests for async database access and add aiosqlite dependency

## Testing
- `flake8 tests/test_molly.py molly.py` (fails: line too long and style issues)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689eeffa49848329b5dcd5202fbcc499