### PR TITLE
Handle exceptions in delayed message

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -358,8 +358,8 @@ async def _delayed_message(app: Application, chat_id: int, state: ChatState, del
         await send_chunk(app, chat_id, state)
     except asyncio.CancelledError:
         pass
-    except Exception:
-        logging.exception("Error in delayed message")
+    except Exception as exc:
+        logging.error("Error in delayed message: %s", exc)
         schedule_next_message(app, chat_id, state)
 
 


### PR DESCRIPTION
## Summary
- log errors from `_delayed_message` and reschedule message dispatch when failures occur

## Testing
- `python -m flake8 molly.py` *(fails: numerous existing style violations)*
- `python -m py_compile molly.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ef07383f88329912a57473ab2589e