### PR TITLE
Fix missing event loop after initialization

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -291,6 +291,7 @@ class ChatState:
 
 chat_states: dict[int, ChatState] = {}
 user_lines, user_weights = asyncio.run(load_user_lines())
+asyncio.set_event_loop(asyncio.new_event_loop())
 
 CLEANUP_INTERVAL = 60
 STALE_AFTER = 3600


### PR DESCRIPTION
## Summary
- Recreate a fresh asyncio event loop after loading user lines to avoid RuntimeError in Python 3.12

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689ef79d9f3883299cc39a8fe4bf52b1