### PR TITLE
Refactor line retention and improve SQLite scalability

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -38,11 +38,15 @@ load_dotenv()
 ORIGIN_TEXT = Path('origin/molly.md')
 LINES_FILE = Path('origin/logs/lines.txt')
 DB_PATH = Path('origin/logs/lines.db')
-_max_lines = os.getenv("MAX_USER_LINES")
-try:
-    MAX_USER_LINES = int(_max_lines) if _max_lines else None
-except ValueError:  # pragma: no cover - invalid values treated as no limit
-    MAX_USER_LINES = None
+
+
+def get_max_user_lines() -> int | None:
+    """Return the configured maximum number of user lines."""
+    _max_lines = os.getenv("MAX_USER_LINES")
+    try:
+        return int(_max_lines) if _max_lines else None
+    except (TypeError, ValueError):  # pragma: no cover - invalid values treated as no limit
+        return None
 CHANGELOG_DB = 'penelopa.db'
 THRESHOLD_BYTES = 100 * 1024  # 100 kilobytes
 MAX_MESSAGE_LENGTH = 4096
@@ -60,24 +64,32 @@ user_weights: list[float] = []
 background_tasks: list[asyncio.Task] = []
 
 
-async def load_user_lines() -> tuple[list[str], list[float]]:
+async def load_user_lines(max_lines: int | None = None) -> tuple[list[str], list[float]]:
     """Return previously stored user lines and weights."""
+    if max_lines is None:
+        max_lines = get_max_user_lines()
     if not DB_PATH.exists():
         return [], []
+    lines: list[str] = []
+    weights: list[float] = []
     try:
         async with aiosqlite.connect(DB_PATH) as conn:
             cursor = await conn.execute(
                 'SELECT line, perplexity, resonance FROM lines ORDER BY id'
             )
-            rows = await cursor.fetchall()
+            while True:
+                rows = await cursor.fetchmany(1000)
+                if not rows:
+                    break
+                for line, perp, res in rows:
+                    lines.append(line)
+                    weights.append((perp or 0.0) + (res or 0.0))
+                if max_lines is not None and len(lines) > max_lines:
+                    lines = lines[-max_lines:]
+                    weights = weights[-max_lines:]
     except Exception:
         logging.exception("Failed to load user lines")
         return [], []
-    lines = [r[0] for r in rows]
-    weights = [(r[1] or 0.0) + (r[2] or 0.0) for r in rows]
-    if MAX_USER_LINES is not None and len(lines) > MAX_USER_LINES:
-        lines = lines[-MAX_USER_LINES:]
-        weights = weights[-MAX_USER_LINES:]
     return lines, weights
 
 
@@ -104,6 +116,9 @@ async def init_db() -> None:
         for col in ('entropy', 'perplexity', 'resonance'):
             if col not in cols:
                 await db_conn.execute(f'ALTER TABLE lines ADD COLUMN {col} REAL')
+        await db_conn.execute(
+            'CREATE INDEX IF NOT EXISTS idx_lines_created_at ON lines (created_at)'
+        )
         await db_conn.commit()
     except Exception:
         logging.exception("Failed to initialize lines database")
@@ -192,22 +207,27 @@ async def store_line(line: str) -> float:
 
 
 async def trim_user_lines(max_lines: int | None = None) -> None:
-    """Trim user_lines, weights, and log file to the last ``max_lines`` entries."""
+    """Trim in-memory and on-disk user lines, archiving removed entries."""
     if max_lines is None:
-        max_lines = MAX_USER_LINES
+        max_lines = get_max_user_lines()
     if max_lines is None:
         return
+    archive_file = LINES_FILE.with_name(f"{LINES_FILE.stem}.archive{LINES_FILE.suffix}")
     async with lines_lock:
         if len(user_lines) <= max_lines:
             return
         del user_lines[:-max_lines]
         del user_weights[:-max_lines]
     with LINES_FILE.open("r+", encoding="utf-8") as f:
-        f.seek(0)
         lines = f.readlines()
+        old_lines = lines[:-max_lines]
         f.seek(0)
         f.writelines(lines[-max_lines:])
         f.truncate()
+    if old_lines:
+        archive_file.parent.mkdir(parents=True, exist_ok=True)
+        with archive_file.open("a", encoding="utf-8") as af:
+            af.writelines(old_lines)
 
 
 def text_chunks() -> Iterator[str]:
@@ -501,8 +521,9 @@ async def handle_message(
     selected = select_prefix_fragments(fragments)
     for frag in fragments:
         await store_line(frag)
-    if MAX_USER_LINES is not None and len(user_lines) > MAX_USER_LINES:
-        await trim_user_lines()
+    max_lines = get_max_user_lines()
+    if max_lines is not None and len(user_lines) > max_lines:
+        await trim_user_lines(max_lines)
     chat_id = update.effective_chat.id
     state = chat_states.setdefault(chat_id, ChatState())
     if selected:

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -76,9 +76,11 @@ def test_trim_user_lines(tmp_path, monkeypatch):
         molly.user_lines[:] = ["a", "b", "c"]
         molly.user_weights[:] = [1.0, 2.0, 3.0]
         await molly.trim_user_lines(max_lines=2)
+        archive_file = lines_file.with_name("lines.archive.txt")
         assert molly.user_lines == ["b", "c"]
         assert molly.user_weights == [2.0, 3.0]
         assert lines_file.read_text(encoding="utf-8") == "b\nc\n"
+        assert archive_file.read_text(encoding="utf-8") == "a\n"
 
     asyncio.run(runner())
 
@@ -90,11 +92,27 @@ def test_trim_user_lines_no_limit(tmp_path, monkeypatch):
         monkeypatch.setattr(molly, "LINES_FILE", lines_file)
         molly.user_lines[:] = ["a", "b", "c"]
         molly.user_weights[:] = [1.0, 2.0, 3.0]
-        monkeypatch.setattr(molly, "MAX_USER_LINES", None)
         await molly.trim_user_lines()
         assert molly.user_lines == ["a", "b", "c"]
         assert molly.user_weights == [1.0, 2.0, 3.0]
         assert lines_file.read_text(encoding="utf-8") == "a\nb\nc\n"
+
+    asyncio.run(runner())
+
+
+def test_trim_user_lines_archives(tmp_path, monkeypatch):
+    async def runner():
+        lines_file = tmp_path / "lines.txt"
+        content = "\n".join(str(i) for i in range(100)) + "\n"
+        lines_file.write_text(content, encoding="utf-8")
+        monkeypatch.setattr(molly, "LINES_FILE", lines_file)
+        molly.user_lines[:] = [str(i) for i in range(100)]
+        molly.user_weights[:] = [float(i) for i in range(100)]
+        await molly.trim_user_lines(max_lines=10)
+        archive_file = lines_file.with_name("lines.archive.txt")
+        assert molly.user_lines == [str(i) for i in range(90, 100)]
+        assert archive_file.read_text(encoding="utf-8").splitlines() == [str(i) for i in range(90)]
+        assert lines_file.read_text(encoding="utf-8").splitlines() == [str(i) for i in range(90, 100)]
 
     asyncio.run(runner())
 
@@ -113,6 +131,28 @@ def test_concurrent_store_line(tmp_path, monkeypatch):
         assert len(molly.user_lines) == 5
         assert set(molly.user_lines) == {f"line {i}" for i in range(5)}
         assert len(molly.user_weights) == 5
+        await molly.db_conn.close()
+        molly.db_conn = None
+
+    asyncio.run(runner())
+
+
+def test_load_user_lines_large(tmp_path, monkeypatch):
+    async def runner():
+        db_path = tmp_path / "lines.db"
+        monkeypatch.setattr(molly, "DB_PATH", db_path)
+        molly.db_conn = None
+        await molly.init_db()
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.executemany(
+                "INSERT INTO lines(line, perplexity, resonance) VALUES (?, ?, ?)",
+                [(f"line {i}", 0.0, 0.0) for i in range(2000)],
+            )
+            await conn.commit()
+        lines, weights = await molly.load_user_lines(max_lines=50)
+        assert len(lines) == 50
+        assert lines[0] == "line 1950"
+        assert all(w == 0.0 for w in weights)
         await molly.db_conn.close()
         molly.db_conn = None
 


### PR DESCRIPTION
## Summary
- make user line retention configurable via `get_max_user_lines`
- archive trimmed lines and batch-load from SQLite with an index for growth
- add high-volume tests for trimming and loading lines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f53a935d08329bc05f1b2c30713a2