### PR TITLE
feat: configure fine-tune threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ graph TD
     root --> LICENSE
 ```
 
+### Configuration
+
+The application reads the following environment variable:
+
+- `FINE_TUNE_THRESHOLD` – size in bytes of logged repository changes that
+  triggers fine-tuning. Defaults to `102400` (100 KB).
+
 ### Technical TL;DR
 
 Penelope listens to every incoming message with a sensor that measures entropy and perplexity, turning language into quantitative signals.

--- a/molly.py
+++ b/molly.py
@@ -44,7 +44,11 @@ try:
 except ValueError:  # pragma: no cover - invalid values treated as no limit
     MAX_USER_LINES = None
 CHANGELOG_DB = 'penelopa.db'
-THRESHOLD_BYTES = 100 * 1024  # 100 kilobytes
+_threshold = os.getenv("FINE_TUNE_THRESHOLD")
+try:
+    THRESHOLD_BYTES = int(_threshold) if _threshold else 100 * 1024
+except ValueError:  # pragma: no cover - invalid values treated as default
+    THRESHOLD_BYTES = 100 * 1024  # 100 kilobytes
 MAX_MESSAGE_LENGTH = 4096
 
 # Global connection to be shared across coroutines

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -9,6 +9,16 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import molly  # noqa: E402
 
 
+def test_threshold_bytes_from_env(monkeypatch):
+    import importlib
+
+    monkeypatch.setenv("FINE_TUNE_THRESHOLD", "2048")
+    importlib.reload(molly)
+    assert molly.THRESHOLD_BYTES == 2048
+    monkeypatch.delenv("FINE_TUNE_THRESHOLD", raising=False)
+    importlib.reload(molly)
+
+
 def test_compute_metrics():
     line = "Love and hate 123 123"
     entropy, perplexity, resonance = molly.compute_metrics(line)


### PR DESCRIPTION
## Summary
- load fine-tune threshold from `FINE_TUNE_THRESHOLD` env var
- document `FINE_TUNE_THRESHOLD` usage in README
- test threshold loading from environment

## Testing
- `flake8` *(fails: E501 line too long etc.)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f543322648329ae5e6489d20e5fe9