### PR TITLE
Support random prefix insertion in generated messages

### DIFF
--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -175,6 +175,49 @@ def test_send_chunk_respects_limit(monkeypatch):
     asyncio.run(runner())
 
 
+def test_send_chunk_inserts_at_position(monkeypatch):
+    class DummyBot:
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+
+        async def send_message(self, chat_id: int, text: str) -> None:
+            self.sent.append(text)
+
+        async def send_chat_action(self, chat_id: int, action: object) -> None:  # pragma: no cover
+            pass
+
+    class DummyApp:
+        def __init__(self, bot: DummyBot) -> None:
+            self.bot = bot
+
+    async def runner():
+        async def no_store(_: str) -> float:
+            return 0.0
+
+        async def no_typing(*args, **kwargs) -> None:
+            return None
+
+        def no_schedule(*args, **kwargs) -> None:
+            return None
+
+        monkeypatch.setattr(molly, "_store_line", no_store)
+        monkeypatch.setattr(molly, "simulate_typing", no_typing)
+        monkeypatch.setattr(molly, "schedule_next_message", no_schedule)
+
+        state = molly.ChatState(generator=iter(["abcdef"]))
+        state.next_prefix = "XYZ"
+        state.next_insert_position = 0.5
+
+        bot = DummyBot()
+        app = DummyApp(bot)
+
+        await molly.send_chunk(app, 1, state)
+
+        assert bot.sent == ["abc XYZ def"]
+
+    asyncio.run(runner())
+
+
 def test_send_chunk_does_not_store_unsent(tmp_path, monkeypatch):
     class FailingBot:
         async def send_message(self, chat_id: int, text: str) -> None:
@@ -261,6 +304,40 @@ def test_handle_message_stores_all_fragments(tmp_path, monkeypatch):
 
         await molly.db_conn.close()
         molly.db_conn = None
+        molly.chat_states.clear()
+
+    asyncio.run(runner())
+
+
+def test_handle_message_sets_insert_position(monkeypatch):
+    async def runner():
+        monkeypatch.setattr(molly, "schedule_next_message", lambda *_, **__: None)
+        monkeypatch.setattr(molly.random, "choice", lambda seq: seq[0])
+        monkeypatch.setattr(molly.random, "choices", lambda seq, weights, k=1: [seq[0]])
+        monkeypatch.setattr(molly.random, "random", lambda: 0.3)
+
+        class DummyMessage:
+            def __init__(self, text: str) -> None:
+                self.text = text
+
+        class DummyUpdate:
+            def __init__(self, text: str) -> None:
+                self.message = DummyMessage(text)
+                self.effective_chat = type("chat", (), {"id": 1})
+
+        class DummyContext:
+            def __init__(self) -> None:
+                self.application = None
+
+        update = DummyUpdate("Hello")
+        context = DummyContext()
+
+        await molly.handle_message(update, context)
+
+        state = molly.chat_states[1]
+        assert state.next_prefix == "Hello"
+        assert state.next_insert_position == 0.3
+
         molly.chat_states.clear()
 
     asyncio.run(runner())


### PR DESCRIPTION
## Summary
- Allow inserting prefixes at random positions within chunks
- Track insertion position in `ChatState` and set it in `handle_message`
- Add tests for random placement and handle message insert position

## Testing
- `ruff check molly.py tests/test_molly.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f54e7e0848329a44a3c9cb0ae36dd