### PR TITLE
Load user lines during startup

### DIFF
--- a/molly.py
+++ b/molly.py
@@ -306,8 +306,8 @@ class ChatState:
 
 
 chat_states: dict[int, ChatState] = {}
-user_lines, user_weights = asyncio.run(load_user_lines())
-asyncio.set_event_loop(asyncio.new_event_loop())
+# Stored user lines are populated during asynchronous startup
+
 
 CLEANUP_INTERVAL = 60
 STALE_AFTER = 3600
@@ -439,6 +439,24 @@ async def monologue(app: Application, chat_id: int) -> None:
     schedule_next_message(app, chat_id, state)
 
 
+async def startup(app: Application) -> None:
+    await init_db()
+    global user_lines, user_weights
+    user_lines, user_weights = await load_user_lines()
+    background_tasks.append(asyncio.create_task(cleanup_chat_states()))
+    background_tasks.append(asyncio.create_task(monitor_repo()))
+
+
+async def shutdown(app: Application) -> None:
+    for task in background_tasks:
+        task.cancel()
+    try:
+        await asyncio.gather(*background_tasks, return_exceptions=True)
+    finally:
+        if db_conn is not None:
+            await db_conn.close()
+
+
 def split_fragments(
     text: str,
     *,
@@ -556,24 +574,10 @@ def main() -> None:
             'TELEGRAM_TOKEN is not set. Provide your bot token via the '
             'TELEGRAM_TOKEN environment variable or a .env file.'
         )
-    async def post_init(app: Application) -> None:
-        await init_db()
-        background_tasks.append(asyncio.create_task(cleanup_chat_states()))
-        background_tasks.append(asyncio.create_task(monitor_repo()))
-
-    async def shutdown(app: Application) -> None:
-        for task in background_tasks:
-            task.cancel()
-        try:
-            await asyncio.gather(*background_tasks, return_exceptions=True)
-        finally:
-            if db_conn is not None:
-                await db_conn.close()
-
     app = (
         Application.builder()
         .token(token)
-        .post_init(post_init)
+        .post_init(startup)
         .post_shutdown(shutdown)
         .build()
     )

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 import math
 import asyncio
+import importlib
 import pytest
 import aiosqlite
 
@@ -217,6 +218,37 @@ def test_send_chunk_does_not_store_unsent(tmp_path, monkeypatch):
 
         await molly.db_conn.close()
         molly.db_conn = None
+
+    asyncio.run(runner())
+
+
+def test_startup_no_side_loop(tmp_path, monkeypatch):
+    async def runner() -> None:
+        mod = importlib.reload(molly)
+        monkeypatch.setattr(mod, "DB_PATH", tmp_path / "lines.db", raising=False)
+
+        async def fake_load() -> tuple[list[str], list[float]]:
+            return ["one"], [1.0]
+
+        async def fake_cleanup() -> None:
+            pass
+
+        async def fake_monitor() -> None:
+            pass
+
+        monkeypatch.setattr(mod, "load_user_lines", fake_load)
+        monkeypatch.setattr(mod, "cleanup_chat_states", fake_cleanup)
+        monkeypatch.setattr(mod, "monitor_repo", fake_monitor)
+        mod.user_lines.clear()
+        mod.user_weights.clear()
+        await mod.startup(None)
+        assert mod.user_lines == ["one"]
+        assert mod.user_weights == [1.0]
+        await asyncio.gather(*mod.background_tasks)
+        mod.background_tasks.clear()
+        if mod.db_conn is not None:
+            await mod.db_conn.close()
+            mod.db_conn = None
 
     asyncio.run(runner())
 


### PR DESCRIPTION
## Summary
- Load stored user lines asynchronously during application startup
- Replace global event loop usage with structured startup/shutdown hooks
- Add test ensuring startup works within an existing event loop

## Testing
- `ruff check molly.py tests/test_molly.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5554e7a48329a7ec90047570ce8e