### PR TITLE
Add resonance factor to compute_delay

### DIFF
--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -25,11 +25,23 @@ def test_compute_delay_respects_daily_target(monkeypatch):
     state = molly.ChatState()
     entropy = 5.0
     perplexity = 10.0
+    resonance = 2.0
     state.daily_target = 8
-    delay_low = molly.compute_delay(state, entropy, perplexity)
+    delay_low = molly.compute_delay(state, entropy, perplexity, resonance)
     state.daily_target = 10
-    delay_high = molly.compute_delay(state, entropy, perplexity)
+    delay_high = molly.compute_delay(state, entropy, perplexity, resonance)
     assert delay_low > delay_high
+
+
+def test_compute_delay_resonance(monkeypatch):
+    monkeypatch.setattr(molly.random, "uniform", lambda a, b: 1)
+    state = molly.ChatState()
+    entropy = 5.0
+    perplexity = 10.0
+    state.daily_target = 8
+    low_res = molly.compute_delay(state, entropy, perplexity, 0.0)
+    high_res = molly.compute_delay(state, entropy, perplexity, 5.0)
+    assert low_res > high_res
 
 
 def test_split_and_select(monkeypatch):


### PR DESCRIPTION
## Summary
- incorporate resonance_factor into `compute_delay` with resonance range handling
- propagate resonance metric in `send_chunk`
- extend delay tests to cover resonance factor

## Testing
- `pytest`
- `python -m pyflakes molly.py tests/test_molly.py`


------
https://chatgpt.com/codex/tasks/task_e_689f54c936d48329a047ce1500130874