### PR TITLE
Use sentiment analyzer for resonance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tiktoken==0.11.0
 PyYAML==6.0.2
 pandas==2.3.1
 aiosqlite==0.20.0
+vaderSentiment==3.3.2

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -28,7 +28,10 @@ def test_compute_metrics():
     expected_perplexity = 2 ** expected_entropy
     assert math.isclose(entropy, expected_entropy, rel_tol=1e-5)
     assert math.isclose(perplexity, expected_perplexity, rel_tol=1e-5)
-    assert resonance == 2
+    compound = molly._sentiment_analyzer.polarity_scores(line)["compound"]
+    num_count = sum(t.isdigit() for t in line.split())
+    expected_resonance = abs(compound) + num_count
+    assert math.isclose(resonance, expected_resonance, rel_tol=1e-5)
 
 
 def test_compute_delay_respects_daily_target(monkeypatch):
@@ -50,7 +53,7 @@ def test_split_and_select(monkeypatch):
     assert fragments == ["Good day", "Bad night", "123 456 789"]
     selected = molly.select_prefix_fragments(fragments)
     lines = [line for line, _ in selected]
-    assert lines == ["123 456 789", "Good day"]
+    assert lines == ["123 456 789", "Bad night"]
 
 
 def test_split_fragments_metrics():


### PR DESCRIPTION
## Summary
- replace manual word lists with VADER sentiment analyzer
- derive resonance from model sentiment score
- adjust metrics tests and expectations

## Testing
- `ruff check molly.py tests/test_molly.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f59693ab08329b801860666ae1659