### PR TITLE
feat: make THRESHOLD_BYTES configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 TELEGRAM_TOKEN=
 # Optional maximum number of stored user lines; leave empty for no limit
 MAX_USER_LINES=
+# Optional threshold in bytes for logged repository changes
+THRESHOLD_BYTES=

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ graph TD
 
 ### Configuration
 
-The application reads the following environment variable:
+The application reads the following configuration, either from environment
+variables or from a `config.ini` file in the working directory:
 
-- `FINE_TUNE_THRESHOLD` – size in bytes of logged repository changes that
-  triggers fine-tuning. Defaults to `102400` (100 KB).
+- `THRESHOLD_BYTES` – size in bytes of logged repository changes that triggers
+  fine-tuning. Defaults to `102400` (100 KB).
 
 ### Technical TL;DR
 

--- a/molly.py
+++ b/molly.py
@@ -15,6 +15,7 @@ import hashlib
 import subprocess
 import tempfile
 import shutil
+import configparser
 
 from telegram import Update
 from telegram.constants import ChatAction
@@ -49,8 +50,16 @@ def get_max_user_lines() -> int | None:
         return int(_max_lines) if _max_lines else None
     except (TypeError, ValueError):  # pragma: no cover - invalid values treated as no limit
         return None
+
+
+def _read_threshold_from_config() -> str | None:
+    config = configparser.ConfigParser()
+    config.read("config.ini")
+    return config.get("DEFAULT", "threshold_bytes", fallback=None)
+
+
 CHANGELOG_DB = 'penelopa.db'
-_threshold = os.getenv("FINE_TUNE_THRESHOLD")
+_threshold = os.getenv("THRESHOLD_BYTES") or _read_threshold_from_config()
 try:
     THRESHOLD_BYTES = int(_threshold) if _threshold else 100 * 1024
 except ValueError:  # pragma: no cover - invalid values treated as default

--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -13,11 +13,21 @@ import molly  # noqa: E402
 def test_threshold_bytes_from_env(monkeypatch):
     import importlib
 
-    monkeypatch.setenv("FINE_TUNE_THRESHOLD", "2048")
+    monkeypatch.setenv("THRESHOLD_BYTES", "2048")
     importlib.reload(molly)
     assert molly.THRESHOLD_BYTES == 2048
-    monkeypatch.delenv("FINE_TUNE_THRESHOLD", raising=False)
+    monkeypatch.delenv("THRESHOLD_BYTES", raising=False)
     importlib.reload(molly)
+
+
+def test_threshold_bytes_from_config(tmp_path, monkeypatch):
+    import importlib
+
+    config_file = tmp_path / "config.ini"
+    config_file.write_text("[DEFAULT]\nthreshold_bytes = 4096", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    importlib.reload(molly)
+    assert molly.THRESHOLD_BYTES == 4096
 
 
 def test_compute_metrics():


### PR DESCRIPTION
## Summary
- load `THRESHOLD_BYTES` from environment variable or `config.ini`
- document configurable threshold
- add tests for environment and config values

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5c7b14c88329879d737a134d1805