### PR TITLE
Maintain queue of prefixes and persist sent chunks

### DIFF
--- a/tests/test_molly.py
+++ b/tests/test_molly.py
@@ -5,6 +5,7 @@ import asyncio
 import importlib
 import pytest
 import aiosqlite
+from collections import deque
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import molly  # noqa: E402
@@ -87,6 +88,8 @@ def test_store_line(tmp_path, monkeypatch):
         lines_file = tmp_path / "lines.txt"
         monkeypatch.setattr(molly, "DB_PATH", db_path)
         monkeypatch.setattr(molly, "LINES_FILE", lines_file)
+        origin_file = tmp_path / "origin.md"
+        monkeypatch.setattr(molly, "ORIGIN_TEXT", origin_file)
         molly.user_lines.clear()
         molly.user_weights.clear()
         molly.db_conn = None
@@ -186,6 +189,8 @@ def test_concurrent_store_line(tmp_path, monkeypatch):
         lines_file = tmp_path / "lines.txt"
         monkeypatch.setattr(molly, "DB_PATH", db_path)
         monkeypatch.setattr(molly, "LINES_FILE", lines_file)
+        origin_file = tmp_path / "origin.md"
+        monkeypatch.setattr(molly, "ORIGIN_TEXT", origin_file)
         molly.user_lines.clear()
         molly.user_weights.clear()
         molly.db_conn = None
@@ -222,7 +227,7 @@ def test_load_user_lines_large(tmp_path, monkeypatch):
     asyncio.run(runner())
 
 
-def test_send_chunk_respects_limit(monkeypatch):
+def test_send_chunk_respects_limit(tmp_path, monkeypatch):
     class DummyBot:
         def __init__(self) -> None:
             self.sent: list[str] = []
@@ -250,10 +255,14 @@ def test_send_chunk_respects_limit(monkeypatch):
         monkeypatch.setattr(molly, "_store_line", no_store)
         monkeypatch.setattr(molly, "simulate_typing", no_typing)
         monkeypatch.setattr(molly, "schedule_next_message", no_schedule)
+        origin_file = tmp_path / "origin.md"
+        monkeypatch.setattr(molly, "ORIGIN_TEXT", origin_file)
 
         long_chunk = "word " * 1000
-        state = molly.ChatState(generator=iter([long_chunk]))
-        state.next_prefix = "prefix"
+        state = molly.ChatState(
+            generator=iter([long_chunk]),
+            prefix_queue=deque([("prefix", 0.0)])
+        )
 
         bot = DummyBot()
         app = DummyApp(bot)
@@ -262,11 +271,12 @@ def test_send_chunk_respects_limit(monkeypatch):
 
         assert len(bot.sent) == 1
         assert len(bot.sent[0]) <= molly.MAX_MESSAGE_LENGTH
+        assert origin_file.read_text(encoding="utf-8").strip() == bot.sent[0]
 
     asyncio.run(runner())
 
 
-def test_send_chunk_inserts_at_position(monkeypatch):
+def test_send_chunk_inserts_at_position(tmp_path, monkeypatch):
     class DummyBot:
         def __init__(self) -> None:
             self.sent: list[str] = []
@@ -294,10 +304,13 @@ def test_send_chunk_inserts_at_position(monkeypatch):
         monkeypatch.setattr(molly, "_store_line", no_store)
         monkeypatch.setattr(molly, "simulate_typing", no_typing)
         monkeypatch.setattr(molly, "schedule_next_message", no_schedule)
+        origin_file = tmp_path / "origin.md"
+        monkeypatch.setattr(molly, "ORIGIN_TEXT", origin_file)
 
-        state = molly.ChatState(generator=iter(["abcdef"]))
-        state.next_prefix = "XYZ"
-        state.next_insert_position = 0.5
+        state = molly.ChatState(
+            generator=iter(["abcdef"]),
+            prefix_queue=deque([("XYZ", 0.5)])
+        )
 
         bot = DummyBot()
         app = DummyApp(bot)
@@ -305,6 +318,7 @@ def test_send_chunk_inserts_at_position(monkeypatch):
         await molly.send_chunk(app, 1, state)
 
         assert bot.sent == ["abc XYZ def"]
+        assert origin_file.read_text(encoding="utf-8").strip() == "abc XYZ def"
 
     asyncio.run(runner())
 
@@ -326,6 +340,8 @@ def test_send_chunk_does_not_store_unsent(tmp_path, monkeypatch):
         lines_file = tmp_path / "lines.txt"
         monkeypatch.setattr(molly, "DB_PATH", db_path)
         monkeypatch.setattr(molly, "LINES_FILE", lines_file)
+        origin_file = tmp_path / "origin.md"
+        monkeypatch.setattr(molly, "ORIGIN_TEXT", origin_file)
         molly.user_lines.clear()
         molly.user_weights.clear()
         molly.db_conn = None
@@ -347,6 +363,7 @@ def test_send_chunk_does_not_store_unsent(tmp_path, monkeypatch):
         await molly.send_chunk(app, 1, state)
 
         assert not lines_file.exists()
+        assert not origin_file.exists()
         assert molly.user_lines == []
 
         await molly.db_conn.close()
@@ -355,7 +372,7 @@ def test_send_chunk_does_not_store_unsent(tmp_path, monkeypatch):
     asyncio.run(runner())
 
 
-def test_send_chunk_resonance_modulates_prefix_probability(monkeypatch):
+def test_send_chunk_resonance_modulates_prefix_probability(tmp_path, monkeypatch):
     class DummyBot:
         def __init__(self) -> None:
             self.sent: list[str] = []
@@ -383,6 +400,8 @@ def test_send_chunk_resonance_modulates_prefix_probability(monkeypatch):
         monkeypatch.setattr(molly, "_store_line", no_store)
         monkeypatch.setattr(molly, "simulate_typing", no_typing)
         monkeypatch.setattr(molly, "schedule_next_message", no_schedule)
+        origin_file = tmp_path / "origin.md"
+        monkeypatch.setattr(molly, "ORIGIN_TEXT", origin_file)
 
         molly.user_lines[:] = ["hi"]
         molly.user_weights[:] = [1.0]
@@ -484,11 +503,9 @@ def test_handle_message_stores_all_fragments(tmp_path, monkeypatch):
     asyncio.run(runner())
 
 
-def test_handle_message_sets_insert_position(monkeypatch):
+def test_handle_message_queues_prefix(monkeypatch):
     async def runner():
         monkeypatch.setattr(molly, "schedule_next_message", lambda *_, **__: None)
-        monkeypatch.setattr(molly.random, "choice", lambda seq: seq[0])
-        monkeypatch.setattr(molly.random, "choices", lambda seq, weights, k=1: [seq[0]])
         monkeypatch.setattr(molly.random, "random", lambda: 0.3)
 
         class DummyMessage:
@@ -510,8 +527,7 @@ def test_handle_message_sets_insert_position(monkeypatch):
         await molly.handle_message(update, context)
 
         state = molly.chat_states[1]
-        assert state.next_prefix == "Hello"
-        assert state.next_insert_position == 0.3
+        assert list(state.prefix_queue) == [("Hello", 0.3)]
 
         molly.chat_states.clear()
 


### PR DESCRIPTION
## Summary
- Queue incoming fragments for repeated prefix insertion
- Insert queued prefixes in multiple positions and cycle them for reuse
- Append sent chunks to the origin text to seed future runs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f6db43e9483299e631122dcdf11a3